### PR TITLE
Fixed onStyleLoaded callback triggering

### DIFF
--- a/maplibre_gl/lib/src/annotation_manager.dart
+++ b/maplibre_gl/lib/src/annotation_manager.dart
@@ -2,6 +2,7 @@ part of '../maplibre_gl.dart';
 
 abstract class AnnotationManager<T extends Annotation> {
   final MapLibreMapController controller;
+
   final _idToAnnotation = <String, T>{};
   final _idToLayerIndex = <String, int>{};
 
@@ -10,6 +11,10 @@ abstract class AnnotationManager<T extends Annotation> {
 
   /// base id of the manager. User [layerdIds] to get the actual ids.
   final String id;
+
+  bool _initialized = false;
+
+  bool get initialized => _initialized;
 
   List<String> get layerIds =>
       [for (int i = 0; i < allLayerProperties.length; i++) _makeLayerId(i)];
@@ -29,23 +34,37 @@ abstract class AnnotationManager<T extends Annotation> {
 
   Set<T> get annotations => _idToAnnotation.values.toSet();
 
-  AnnotationManager(this.controller,
-      {String? id,
-      this.onTap,
-      this.selectLayer,
-      required this.enableInteraction})
-      : id = id ?? getRandomString() {
+  AnnotationManager(
+    this.controller, {
+    String? id,
+    this.onTap,
+    this.selectLayer,
+    required this.enableInteraction,
+  }) : id = id ?? getRandomString();
+
+  @mustCallSuper
+  Future<void> initialize() async {
+    if (_initialized) {
+      return;
+    }
+
     for (var i = 0; i < allLayerProperties.length; i++) {
       final layerId = _makeLayerId(i);
-      controller.addGeoJsonSource(layerId, buildFeatureCollection([]),
-          promoteId: "id");
-      controller.addLayer(layerId, layerId, allLayerProperties[i]);
+
+      await controller.addGeoJsonSource(
+        layerId,
+        buildFeatureCollection([]),
+        promoteId: "id",
+      );
+      await controller.addLayer(layerId, layerId, allLayerProperties[i]);
     }
 
     if (onTap != null) {
       controller.onFeatureTapped.add(_onFeatureTapped);
     }
     controller.onFeatureDrag.add(_onDrag);
+
+    _initialized = true;
   }
 
   /// This function can be used to rebuild all layers after their properties

--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -1331,7 +1331,7 @@ class MapLibreMapController extends ChangeNotifier {
       double? maxzoom,
       dynamic filter}) async {
     if (properties is FillLayerProperties) {
-      addFillLayer(sourceId, layerId, properties,
+      await addFillLayer(sourceId, layerId, properties,
           belowLayerId: belowLayerId,
           enableInteraction: enableInteraction,
           sourceLayer: sourceLayer,
@@ -1339,13 +1339,13 @@ class MapLibreMapController extends ChangeNotifier {
           maxzoom: maxzoom,
           filter: filter);
     } else if (properties is FillExtrusionLayerProperties) {
-      addFillExtrusionLayer(sourceId, layerId, properties,
+      await addFillExtrusionLayer(sourceId, layerId, properties,
           belowLayerId: belowLayerId,
           sourceLayer: sourceLayer,
           minzoom: minzoom,
           maxzoom: maxzoom);
     } else if (properties is LineLayerProperties) {
-      addLineLayer(sourceId, layerId, properties,
+      await addLineLayer(sourceId, layerId, properties,
           belowLayerId: belowLayerId,
           enableInteraction: enableInteraction,
           sourceLayer: sourceLayer,
@@ -1353,7 +1353,7 @@ class MapLibreMapController extends ChangeNotifier {
           maxzoom: maxzoom,
           filter: filter);
     } else if (properties is SymbolLayerProperties) {
-      addSymbolLayer(sourceId, layerId, properties,
+      await addSymbolLayer(sourceId, layerId, properties,
           belowLayerId: belowLayerId,
           enableInteraction: enableInteraction,
           sourceLayer: sourceLayer,
@@ -1361,7 +1361,7 @@ class MapLibreMapController extends ChangeNotifier {
           maxzoom: maxzoom,
           filter: filter);
     } else if (properties is CircleLayerProperties) {
-      addCircleLayer(sourceId, layerId, properties,
+      await addCircleLayer(sourceId, layerId, properties,
           belowLayerId: belowLayerId,
           enableInteraction: enableInteraction,
           sourceLayer: sourceLayer,
@@ -1372,7 +1372,7 @@ class MapLibreMapController extends ChangeNotifier {
       if (filter != null) {
         throw UnimplementedError("RasterLayer does not support filter");
       }
-      addRasterLayer(sourceId, layerId, properties,
+      await addRasterLayer(sourceId, layerId, properties,
           belowLayerId: belowLayerId,
           sourceLayer: sourceLayer,
           minzoom: minzoom,
@@ -1381,13 +1381,13 @@ class MapLibreMapController extends ChangeNotifier {
       if (filter != null) {
         throw UnimplementedError("HillShadeLayer does not support filter");
       }
-      addHillshadeLayer(sourceId, layerId, properties,
+      await addHillshadeLayer(sourceId, layerId, properties,
           belowLayerId: belowLayerId,
           sourceLayer: sourceLayer,
           minzoom: minzoom,
           maxzoom: maxzoom);
     } else if (properties is HeatmapLayerProperties) {
-      addHeatmapLayer(sourceId, layerId, properties,
+      await addHeatmapLayer(sourceId, layerId, properties,
           belowLayerId: belowLayerId,
           sourceLayer: sourceLayer,
           minzoom: minzoom,

--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -129,7 +129,7 @@ class MapLibreMapController extends ChangeNotifier {
       notifyListeners();
     });
 
-    _maplibrePlatform.onMapStyleLoadedPlatform.add((_) {
+    _maplibrePlatform.onMapStyleLoadedPlatform.add((_) async {
       final interactionEnabled = annotationConsumeTapEvents.toSet();
       for (final type in annotationOrder.toSet()) {
         final enableInteraction = interactionEnabled.contains(type);
@@ -137,17 +137,21 @@ class MapLibreMapController extends ChangeNotifier {
           case AnnotationType.fill:
             fillManager = FillManager(this,
                 onTap: onFillTapped.call, enableInteraction: enableInteraction);
+            await fillManager!.initialize();
           case AnnotationType.line:
             lineManager = LineManager(this,
                 onTap: onLineTapped.call, enableInteraction: enableInteraction);
+            await lineManager!.initialize();
           case AnnotationType.circle:
             circleManager = CircleManager(this,
                 onTap: onCircleTapped.call,
                 enableInteraction: enableInteraction);
+            await circleManager!.initialize();
           case AnnotationType.symbol:
             symbolManager = SymbolManager(this,
                 onTap: onSymbolTapped.call,
                 enableInteraction: enableInteraction);
+            await symbolManager!.initialize();
         }
       }
       onStyleLoadedCallback?.call();

--- a/maplibre_gl_web/lib/src/convert.dart
+++ b/maplibre_gl_web/lib/src/convert.dart
@@ -20,7 +20,7 @@ class Convert {
       sink.setCompassEnabled(options['compassEnabled']);
     }
     if (options.containsKey('styleString')) {
-      sink.setStyleString(options['styleString']);
+      sink.setStyleString(options['styleString'], allowDiff: false);
     }
     if (options.containsKey('minMaxZoomPreference')) {
       sink.setMinMaxZoomPreference(options['minMaxZoomPreference'][0],

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -2,6 +2,8 @@ part of '../maplibre_gl_web.dart';
 
 class MapLibreMapController extends MapLibrePlatform
     implements MapLibreMapOptionsSink {
+  static const _styleLoadedCheckBackoff = Duration(milliseconds: 100);
+
   late html.DivElement _mapElement;
 
   late Map<String, dynamic> _creationParams;
@@ -168,6 +170,21 @@ class MapLibreMapController extends MapLibrePlatform
       };
       _dragPrevious = current;
       onFeatureDraggedPlatform(payload);
+    }
+  }
+
+  /// Callback for `styleData` event.
+  /// Used to handle style load after setStyle is called.
+  void _onStyleData(dynamic event) {
+    // Check if style is fully loaded
+    if (_map.isStyleLoaded()) {
+      _onStyleLoaded(event);
+    } else {
+      // Style is still being loaded, back off and try again later
+      Future.delayed(
+        _styleLoadedCheckBackoff,
+        () => _onStyleData(event),
+      );
     }
   }
 
@@ -709,7 +726,7 @@ class MapLibreMapController extends MapLibrePlatform
     _map.setStyle(styleString);
     // catch style loaded for later style changes
     if (_mapReady) {
-      _map.once("styledata", _onStyleLoaded);
+      _map.once("styledata", _onStyleData);
     }
   }
 

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -713,7 +713,7 @@ class MapLibreMapController extends MapLibrePlatform
   }
 
   @override
-  void setStyleString(String? styleString) {
+  void setStyleString(String? styleString, {bool allowDiff = true}) {
     //remove old mouseenter callbacks to avoid multicalling
     for (final layerId in _interactiveFeatureLayerIds) {
       _map.off('mouseenter', layerId, _onMouseEnterFeature);
@@ -723,7 +723,7 @@ class MapLibreMapController extends MapLibrePlatform
     }
     _interactiveFeatureLayerIds.clear();
 
-    _map.setStyle(styleString);
+    _map.setStyle(styleString, {"diff": allowDiff});
     // catch style loaded for later style changes
     if (_mapReady) {
       _map.once("styledata", _onStyleData);

--- a/maplibre_gl_web/lib/src/options_sink.dart
+++ b/maplibre_gl_web/lib/src/options_sink.dart
@@ -7,7 +7,7 @@ abstract class MapLibreMapOptionsSink {
   void setCompassEnabled(bool compassEnabled);
 
   // TODO: styleString is not actually a part of options. consider moving
-  void setStyleString(String? styleString);
+  void setStyleString(String? styleString, {bool allowDiff});
 
   void setMinMaxZoomPreference(num? min, num? max);
 

--- a/maplibre_gl_web/lib/src/ui/map.dart
+++ b/maplibre_gl_web/lib/src/ui/map.dart
@@ -495,7 +495,7 @@ class MapLibreMap extends Camera {
   ///  @returns {MapLibreMap} `this`
   ///  @see [Change a map's style](https://maplibre.org/maplibre-gl-js/docs/examples/setstyle/)
   MapLibreMap setStyle(dynamic style, [dynamic options]) =>
-      MapLibreMap.fromJsObject(jsObject.setStyle(style));
+      MapLibreMap.fromJsObject(jsObject.setStyle(style, options));
 
   ///  Returns the map's MapLibre style object, which can be used to recreate the map's style.
   ///


### PR DESCRIPTION
According to [this](https://stackoverflow.com/a/51145266), the way maplibre-gl-web handles onStyleLoaded callbacks after setStyle call is incorrect. The onStyleCallback is called even if style is still loading.

This PR adds periodic check for style loading state and calls the onStyleLoaded callback only after `map.isStyleLoaded()` returns true. Map `idle` event didn't seem to work so I went with this as it seems to be foolproof so far. See [this thread](https://osmus.slack.com/archives/C03TFH5NE83/p1742293668185129) for more information.

I used period of 100ms for the checks, but maybe exponential or linear backoff with upper bound would be more suitable?

### How to test

Go through each package in this project (`maplibre_gl`, `maplibre_gl_web`, `maplibre_gl_platform_interface`) and go to pubspec.yaml. For each package there will be `git` dependency on the other package, e.g. `maplibre_gl` depending on `maplibre_gl_platform_interface`. Change it from `git` to `path: ../maplibre_gl_platform_interface`. Do this for each such dependency.

Testing this is very easy then, just open Dronemap and try rapidly switching between standard and satellite map. Previous version would eventually fail as manager layers would be overwritten by the fully loaded style.

DT-3906