### PR TITLE
Initialized annotation manager in a separate `initialize()` method

### DIFF
--- a/maplibre_gl/lib/src/annotation_manager.dart
+++ b/maplibre_gl/lib/src/annotation_manager.dart
@@ -2,6 +2,7 @@ part of '../maplibre_gl.dart';
 
 abstract class AnnotationManager<T extends Annotation> {
   final MapLibreMapController controller;
+
   final _idToAnnotation = <String, T>{};
   final _idToLayerIndex = <String, int>{};
 
@@ -10,6 +11,10 @@ abstract class AnnotationManager<T extends Annotation> {
 
   /// base id of the manager. User [layerdIds] to get the actual ids.
   final String id;
+
+  bool _initialized = false;
+
+  bool get initialized => _initialized;
 
   List<String> get layerIds =>
       [for (int i = 0; i < allLayerProperties.length; i++) _makeLayerId(i)];
@@ -29,23 +34,37 @@ abstract class AnnotationManager<T extends Annotation> {
 
   Set<T> get annotations => _idToAnnotation.values.toSet();
 
-  AnnotationManager(this.controller,
-      {String? id,
-      this.onTap,
-      this.selectLayer,
-      required this.enableInteraction})
-      : id = id ?? getRandomString() {
+  AnnotationManager(
+    this.controller, {
+    String? id,
+    this.onTap,
+    this.selectLayer,
+    required this.enableInteraction,
+  }) : id = id ?? getRandomString();
+
+  @mustCallSuper
+  Future<void> initialize() async {
+    if (_initialized) {
+      return;
+    }
+
     for (var i = 0; i < allLayerProperties.length; i++) {
       final layerId = _makeLayerId(i);
-      controller.addGeoJsonSource(layerId, buildFeatureCollection([]),
-          promoteId: "id");
-      controller.addLayer(layerId, layerId, allLayerProperties[i]);
+
+      await controller.addGeoJsonSource(
+        layerId,
+        buildFeatureCollection([]),
+        promoteId: "id",
+      );
+      await controller.addLayer(layerId, layerId, allLayerProperties[i]);
     }
 
     if (onTap != null) {
       controller.onFeatureTapped.add(_onFeatureTapped);
     }
     controller.onFeatureDrag.add(_onDrag);
+
+    _initialized = true;
   }
 
   /// This function can be used to rebuild all layers after their properties

--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -129,7 +129,7 @@ class MapLibreMapController extends ChangeNotifier {
       notifyListeners();
     });
 
-    _maplibrePlatform.onMapStyleLoadedPlatform.add((_) {
+    _maplibrePlatform.onMapStyleLoadedPlatform.add((_) async {
       final interactionEnabled = annotationConsumeTapEvents.toSet();
       for (final type in annotationOrder.toSet()) {
         final enableInteraction = interactionEnabled.contains(type);
@@ -137,17 +137,21 @@ class MapLibreMapController extends ChangeNotifier {
           case AnnotationType.fill:
             fillManager = FillManager(this,
                 onTap: onFillTapped.call, enableInteraction: enableInteraction);
+            await fillManager!.initialize();
           case AnnotationType.line:
             lineManager = LineManager(this,
                 onTap: onLineTapped.call, enableInteraction: enableInteraction);
+            await lineManager!.initialize();
           case AnnotationType.circle:
             circleManager = CircleManager(this,
                 onTap: onCircleTapped.call,
                 enableInteraction: enableInteraction);
+            await circleManager!.initialize();
           case AnnotationType.symbol:
             symbolManager = SymbolManager(this,
                 onTap: onSymbolTapped.call,
                 enableInteraction: enableInteraction);
+            await symbolManager!.initialize();
         }
       }
       onStyleLoadedCallback?.call();


### PR DESCRIPTION
Separates `AnnotationManager` instance to separate method which can be properly awaited. Previously there were unawaited async calls in `AnnotationManager` constructor which could potentially cause race conditions and also improper layer ordering between different managers.