### PR TITLE
Optimize feature add/set/remove by batching

### DIFF
--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -395,21 +395,52 @@ final class MapLibreMapController
     geoJsonSource.setGeoJson(featureCollection);
   }
 
-  private void setGeoJsonFeature(String sourceName, String geojsonFeature) {
-    Feature feature = Feature.fromJson(geojsonFeature);
+  private void setGeoJsonFeatures(String sourceName, List<String> geojsonFeatures) {
     FeatureCollection featureCollection = addedFeaturesByLayer.get(sourceName);
     GeoJsonSource geoJsonSource = style.getSourceAs(sourceName);
-    if (featureCollection != null && geoJsonSource != null) {
-      final List<Feature> features = featureCollection.features();
+
+    if (featureCollection == null || geoJsonSource == null) {
+      // TODO create new source if it does not exist
+      return;
+    }
+
+    final List<Feature> features = featureCollection.features();
+    if (features == null) {
+      // TODO handle and create new feature list if it is null
+      return;
+    }
+
+    for (final String geojsonFeature : geojsonFeatures) {
+      Feature feature = Feature.fromJson(geojsonFeature);
+      final String featureId = feature.id();
+
+      if (featureId == null) {
+        continue;
+      }
+
+      int firstIndex = -1;
       for (int i = 0; i < features.size(); i++) {
-        final String id = features.get(i).id();
-        if (id.equals(feature.id())) {
+        final String collectionFeatureId = features.get(i).id();
+        if (collectionFeatureId == null) {
+          continue;
+        }
+
+        if (collectionFeatureId.equals(featureId)) {
           features.set(i, feature);
+          firstIndex = i;
           break;
         }
       }
 
-      geoJsonSource.setGeoJson(featureCollection);
+      if (firstIndex < 0) {
+        // Feature is new, add it to feature collection
+        features.add(feature);
+      }
+    }
+
+    geoJsonSource.setGeoJson(featureCollection);
+  }
+
     }
   }
 
@@ -975,6 +1006,14 @@ final class MapLibreMapController
           break;
         }
       case "source#setFeature":
+      case "source#setFeatures":
+        {
+          final String sourceId = call.argument("sourceId");
+          final List<String> geojsonFeatures = call.argument("geojsonFeatures");
+          setGeoJsonFeatures(sourceId, geojsonFeatures);
+          result.success(null);
+          break;
+        }
         {
           final String sourceId = call.argument("sourceId");
           final String geojsonFeature = call.argument("geojsonFeature");

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -441,7 +441,40 @@ final class MapLibreMapController
     geoJsonSource.setGeoJson(featureCollection);
   }
 
+  private void removeGeoJsonFeatures(String sourceName, List<String> featureIds) {
+    FeatureCollection featureCollection = addedFeaturesByLayer.get(sourceName);
+    GeoJsonSource geoJsonSource = style.getSourceAs(sourceName);
+
+    if (featureCollection == null || geoJsonSource == null) {
+      // TODO create new source if it does not exist
+      return;
     }
+
+    final List<Feature> features = featureCollection.features();
+    if (features == null) {
+      // TODO handle and create new feature list if it is null
+      return;
+    }
+
+    for (final String featureId : featureIds) {
+      if (featureId == null) {
+        continue;
+      }
+
+      for (int i = 0; i < features.size(); i++) {
+        final String collectionFeatureId = features.get(i).id();
+        if (collectionFeatureId == null) {
+          continue;
+        }
+
+        if (collectionFeatureId.equals(featureId)) {
+          features.remove(i);
+          break;
+        }
+      }
+    }
+
+    geoJsonSource.setGeoJson(featureCollection);
   }
 
   private void addSymbolLayer(
@@ -1005,7 +1038,6 @@ final class MapLibreMapController
           result.success(null);
           break;
         }
-      case "source#setFeature":
       case "source#setFeatures":
         {
           final String sourceId = call.argument("sourceId");
@@ -1014,10 +1046,11 @@ final class MapLibreMapController
           result.success(null);
           break;
         }
+      case "source#removeFeatures":
         {
           final String sourceId = call.argument("sourceId");
-          final String geojsonFeature = call.argument("geojsonFeature");
-          setGeoJsonFeature(sourceId, geojsonFeature);
+          final List<String> featureIds = call.argument("featureIds");
+          removeGeoJsonFeatures(sourceId, featureIds);
           result.success(null);
           break;
         }

--- a/maplibre_gl/lib/src/annotation_manager.dart
+++ b/maplibre_gl/lib/src/annotation_manager.dart
@@ -114,30 +114,62 @@ abstract class AnnotationManager<T extends Annotation> {
   /// Adds a multiple annotations to the map. This much faster than calling add
   /// multiple times
   Future<void> addAll(Iterable<T> annotations) async {
+    final annotationGeojsonsByLayer = <int, List<Map<String, dynamic>>>{};
+
     for (final a in annotations) {
+      final layerIndex = selectLayer != null ? selectLayer!(a) : 0;
       _idToAnnotation[a.id] = a;
+
+      final annotations = annotationGeojsonsByLayer[layerIndex];
+      annotationGeojsonsByLayer[layerIndex] = (annotations ?? <Map<String, dynamic>>[])..add(a.toGeoJson());
     }
-    await _setAll();
+
+    for (final layerIndex in annotationGeojsonsByLayer.keys) {
+      final layerId = _makeLayerId(layerIndex);
+      final geojsons = annotationGeojsonsByLayer[layerIndex];
+
+      if (geojsons != null && geojsons.isNotEmpty) {
+        await controller.setGeoJsonFeatures(layerId, geojsons);
+      }
+    }
   }
 
   /// add a single annotation to the map
   Future<void> add(T annotation) async {
     _idToAnnotation[annotation.id] = annotation;
-    await _setAll();
+    final layerIndex = selectLayer != null ? selectLayer!(annotation) : 0;
+    await controller.setGeoJsonFeature(
+        _makeLayerId(layerIndex), annotation.toGeoJson());
   }
 
   /// Removes multiple annotations from the map
   Future<void> removeAll(Iterable<T> annotations) async {
+    final annotationIdsByLayer = <int, List<dynamic>>{};
+
     for (final a in annotations) {
+      final layerIndex = selectLayer != null ? selectLayer!(a) : 0;
       _idToAnnotation.remove(a.id);
+
+      final ids = annotationIdsByLayer[layerIndex];
+      annotationIdsByLayer[layerIndex] = (ids ?? <dynamic>[])..add(a.id);
     }
-    await _setAll();
+
+    for (final layerIndex in annotationIdsByLayer.keys) {
+      final layerId = _makeLayerId(layerIndex);
+      final annotationIds = annotationIdsByLayer[layerIndex];
+
+      if (annotationIds != null && annotationIds.isNotEmpty) {
+        await controller.removeGeoJsonFeatures(layerId, annotationIds);
+      }
+    }
   }
 
   /// Remove a single annotation form the map
   Future<void> remove(T annotation) async {
+    final layerIndex = selectLayer != null ? selectLayer!(annotation) : 0;
     _idToAnnotation.remove(annotation.id);
-    await _setAll();
+    await controller
+        .removeGeoJsonFeatures(_makeLayerId(layerIndex), [annotation.id]);
   }
 
   /// Removes all annotations from the map

--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -359,6 +359,12 @@ class MapLibreMapController extends ChangeNotifier {
         sourceId, geojsonFeatures);
   }
 
+  // TODO document
+  Future<void> removeGeoJsonFeatures(
+      String sourceId, List<dynamic> featureIds) async {
+    await _maplibrePlatform.removeFeaturesForGeoJsonSource(sourceId, featureIds);
+  }
+
   /// Add a symbol layer to the map with the given properties
   ///
   /// Consider using [addLayer] for an unified layer api.

--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -347,10 +347,16 @@ class MapLibreMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes after the change has been made on the
   /// platform side.
+  // TODO deprecate
   Future<void> setGeoJsonFeature(
-      String sourceId, Map<String, dynamic> geojsonFeature) async {
-    await _maplibrePlatform.setFeatureForGeoJsonSource(
-        sourceId, geojsonFeature);
+          String sourceId, Map<String, dynamic> geojsonFeature) =>
+      setGeoJsonFeatures(sourceId, [geojsonFeature]);
+
+  // TODO document
+  Future<void> setGeoJsonFeatures(
+      String sourceId, List<Map<String, dynamic>> geojsonFeatures) async {
+    await _maplibrePlatform.setFeaturesForGeoJsonSource(
+        sourceId, geojsonFeatures);
   }
 
   /// Add a symbol layer to the map with the given properties

--- a/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
+++ b/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
@@ -128,6 +128,9 @@ abstract class MapLibrePlatform {
   Future<void> setFeaturesForGeoJsonSource(
       String sourceId, List<Map<String, dynamic>> geojsonFeatures);
 
+  Future<void> removeFeaturesForGeoJsonSource(
+      String sourceId, List<dynamic> featureIds);
+
   Future<void> removeSource(String sourceId);
 
   Future<void> addSymbolLayer(

--- a/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
+++ b/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
@@ -125,8 +125,8 @@ abstract class MapLibrePlatform {
     required int padding,
   });
 
-  Future<void> setFeatureForGeoJsonSource(
-      String sourceId, Map<String, dynamic> geojsonFeature);
+  Future<void> setFeaturesForGeoJsonSource(
+      String sourceId, List<Map<String, dynamic>> geojsonFeatures);
 
   Future<void> removeSource(String sourceId);
 

--- a/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
+++ b/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
@@ -791,12 +791,17 @@ class MapLibreMethodChannel extends MapLibrePlatform {
   }
 
   @override
-  Future<void> setFeatureForGeoJsonSource(
-      String sourceId, Map<String, dynamic> geojsonFeature) async {
-    await _channel.invokeMethod('source#setFeature', <String, dynamic>{
-      'sourceId': sourceId,
-      'geojsonFeature': jsonEncode(geojsonFeature)
-    });
+  Future<void> setFeaturesForGeoJsonSource(
+      String sourceId, List<Map<String, dynamic>> geojsonFeatures) async {
+    // TODO make idempotent (adding likely not supported)
+    // TODO implement true batch processing
+
+    for (final geojsonFeature in geojsonFeatures) {
+      await _channel.invokeMethod('source#setFeature', <String, dynamic>{
+        'sourceId': sourceId,
+        'geojsonFeature': jsonEncode(geojsonFeature)
+      });
+    }
   }
 
   @override

--- a/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
+++ b/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
@@ -793,15 +793,11 @@ class MapLibreMethodChannel extends MapLibrePlatform {
   @override
   Future<void> setFeaturesForGeoJsonSource(
       String sourceId, List<Map<String, dynamic>> geojsonFeatures) async {
-    // TODO make idempotent (adding likely not supported)
-    // TODO implement true batch processing
-
-    for (final geojsonFeature in geojsonFeatures) {
-      await _channel.invokeMethod('source#setFeature', <String, dynamic>{
-        'sourceId': sourceId,
-        'geojsonFeature': jsonEncode(geojsonFeature)
-      });
-    }
+    await _channel.invokeMethod('source#setFeatures', <String, dynamic>{
+      'sourceId': sourceId,
+      'geojsonFeatures':
+          geojsonFeatures.map((feature) => jsonEncode(feature)).toList(),
+    });
   }
 
   @override

--- a/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
+++ b/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
@@ -805,6 +805,15 @@ class MapLibreMethodChannel extends MapLibrePlatform {
   }
 
   @override
+  Future<void> removeFeaturesForGeoJsonSource(
+      String sourceId, List<dynamic> featureIds) async {
+    await _channel.invokeMethod('source#removeFeatures', <String, dynamic>{
+      'sourceId': sourceId,
+      'featureIds': featureIds,
+    });
+  }
+
+  @override
   Future<void> setLayerVisibility(String layerId, bool visible) async {
     await _channel.invokeMethod('layer#setVisibility', <String, dynamic>{
       'layerId': layerId,

--- a/maplibre_gl_web/lib/maplibre_gl_web.dart
+++ b/maplibre_gl_web/lib/maplibre_gl_web.dart
@@ -26,6 +26,7 @@ import 'package:maplibre_gl_web/src/geo/lng_lat.dart';
 import 'package:maplibre_gl_web/src/geo/lng_lat_bounds.dart';
 import 'package:maplibre_gl_web/src/layer_tools.dart';
 import 'package:maplibre_gl_web/src/style/sources/geojson_source.dart';
+import 'package:maplibre_gl_web/src/style/sources/geojson_source_diff.dart';
 import 'package:maplibre_gl_web/src/ui/camera.dart';
 import 'package:maplibre_gl_web/src/ui/control/attribution_control.dart';
 import 'package:maplibre_gl_web/src/ui/control/geolocate_control.dart';

--- a/maplibre_gl_web/lib/src/interop/style/sources/geojson_source_diff_interop.dart
+++ b/maplibre_gl_web/lib/src/interop/style/sources/geojson_source_diff_interop.dart
@@ -1,0 +1,60 @@
+import 'package:js/js.dart';
+import 'package:maplibre_gl_web/src/interop/geo/geojson_interop.dart';
+
+// TODO define as "number | string"
+typedef GeoJsonFeatureId = dynamic;
+
+@JS()
+@anonymous
+class GeoJsonSourceDiffJsImpl {
+  external factory GeoJsonSourceDiffJsImpl({
+    bool? removeAll,
+    List<GeoJsonFeatureId>? remove,
+    // TODO use [FeatureJsImpl] when it uses js_interop
+    List<FeatureJsImpl>? add,
+    List<GeoJsonFeatureDiffJsImpl>? update,
+  });
+
+  external bool? get removeAll;
+
+  external List<GeoJsonFeatureId>? get remove;
+
+  external List<FeatureJsImpl>? get add;
+
+  external List<GeoJsonFeatureDiffJsImpl>? get update;
+}
+
+@JS()
+@anonymous
+class GeoJsonFeatureDiffJsImpl {
+  external factory GeoJsonFeatureDiffJsImpl({
+    GeoJsonFeatureId id,
+    GeometryJsImpl? newGeometry,
+    bool? removeAllProperties,
+    List<String>? removeProperties,
+    List<FeaturePropertyUpdateJsImpl>? addOrUpdateProperties,
+  });
+
+  external GeoJsonFeatureId get id;
+
+  external GeometryJsImpl? get newGeometry;
+
+  external bool? get removeAllProperties;
+
+  external List<String>? get removeProperties;
+
+  external List<FeaturePropertyUpdateJsImpl>? get addOrUpdateProperties;
+}
+
+@JS()
+@anonymous
+class FeaturePropertyUpdateJsImpl {
+  external factory FeaturePropertyUpdateJsImpl({
+    String key,
+    dynamic value,
+  });
+
+  external String get key;
+
+  external dynamic get value;
+}

--- a/maplibre_gl_web/lib/src/interop/style/sources/geojson_source_interop.dart
+++ b/maplibre_gl_web/lib/src/interop/style/sources/geojson_source_interop.dart
@@ -4,6 +4,8 @@ library maplibre.style.interop.sources.geojson_source;
 import 'package:js/js.dart';
 import 'package:maplibre_gl_web/src/interop/geo/geojson_interop.dart';
 
+import 'geojson_source_diff_interop.dart';
+
 @JS()
 @anonymous
 class GeoJsonSourceJsImpl {
@@ -19,4 +21,6 @@ class GeoJsonSourceJsImpl {
 
   external GeoJsonSourceJsImpl setData(
       FeatureCollectionJsImpl featureCollection);
+
+  external GeoJsonSourceJsImpl updateData(GeoJsonSourceDiffJsImpl diff);
 }

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -1132,13 +1132,40 @@ class MapLibreMapController extends MapLibrePlatform
     if (source != null && data != null) {
       final feature = _makeFeature(geojsonFeature);
       final features = data.features.toList();
+
       final index = features.indexWhere((f) => f.id == feature.id);
       if (index >= 0) {
+        // Feature exists, update all fields
         features[index] = feature;
         final newData = FeatureCollection(features: features);
         _addedFeaturesByLayer[sourceId] = newData;
 
-        source.setData(newData);
+        print(
+            'Performing feature update for source ${sourceId}, feature ${feature.id}');
+        source.updateData(GeoJsonSourceDiff(
+          update: [
+            GeoJsonFeatureDiff(
+              id: feature.id,
+              newGeometry: feature.geometry,
+              removeAllProperties: true,
+              addOrUpdateProperties: [
+                for (final entry in feature.properties.entries)
+                  FeaturePropertyUpdate(entry.key, entry.value)
+              ],
+            )
+          ],
+        ));
+      } else {
+        // Feature is new, add it
+        features.add(feature);
+        final newData = FeatureCollection(features: features);
+        _addedFeaturesByLayer[sourceId] = newData;
+
+        print(
+            'Adding new feature for source ${sourceId}, feature ${feature.id}');
+        source.updateData(GeoJsonSourceDiff(
+          add: [feature],
+        ));
       }
     }
   }

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -1170,8 +1170,36 @@ class MapLibreMapController extends MapLibrePlatform
     final newData = FeatureCollection(features: features);
     _addedFeaturesByLayer[sourceId] = newData;
   }
-      }
+
+  @override
+  Future<void> removeFeaturesForGeoJsonSource(
+      String sourceId, List<dynamic> featureIds) async {
+    final source = _map.getSource(sourceId) as GeoJsonSource?;
+    final data = _addedFeaturesByLayer[sourceId];
+
+    if (source == null || data == null) {
+      return;
     }
+
+    final removedFeatures = <dynamic>[];
+
+    // Create copy of current features in source
+    final features = data.features.toList();
+
+    for (final featureId in featureIds) {
+      final index = features.indexWhere((f) => f.id == featureId);
+      if (index < 0) {
+        continue;
+      }
+
+      features.removeAt(index);
+      removedFeatures.add(featureId);
+    }
+
+    source.updateData(GeoJsonSourceDiff(remove: removedFeatures));
+
+    final newData = FeatureCollection(features: features);
+    _addedFeaturesByLayer[sourceId] = newData;
   }
 
   @override

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -1124,48 +1124,52 @@ class MapLibreMapController extends MapLibrePlatform
   }
 
   @override
-  Future<void> setFeatureForGeoJsonSource(
-      String sourceId, Map<String, dynamic> geojsonFeature) async {
+  Future<void> setFeaturesForGeoJsonSource(
+      String sourceId, List<Map<String, dynamic>> geojsonFeatures) async {
     final source = _map.getSource(sourceId) as GeoJsonSource?;
     final data = _addedFeaturesByLayer[sourceId];
 
-    if (source != null && data != null) {
+    if (source == null || data == null) {
+      return;
+    }
+
+    final updatedFeatures = <GeoJsonFeatureDiff>[];
+    final newFeatures = <Feature>[];
+
+    // Create copy of current features in source
+    final features = data.features.toList();
+
+    for (final geojsonFeature in geojsonFeatures) {
       final feature = _makeFeature(geojsonFeature);
-      final features = data.features.toList();
 
       final index = features.indexWhere((f) => f.id == feature.id);
       if (index >= 0) {
         // Feature exists, update all fields
         features[index] = feature;
-        final newData = FeatureCollection(features: features);
-        _addedFeaturesByLayer[sourceId] = newData;
-
-        print(
-            'Performing feature update for source ${sourceId}, feature ${feature.id}');
-        source.updateData(GeoJsonSourceDiff(
-          update: [
-            GeoJsonFeatureDiff(
-              id: feature.id,
-              newGeometry: feature.geometry,
-              removeAllProperties: true,
-              addOrUpdateProperties: [
-                for (final entry in feature.properties.entries)
-                  FeaturePropertyUpdate(entry.key, entry.value)
-              ],
-            )
+        updatedFeatures.add(GeoJsonFeatureDiff(
+          id: feature.id,
+          newGeometry: feature.geometry,
+          removeAllProperties: true,
+          addOrUpdateProperties: [
+            for (final entry in feature.properties.entries)
+              FeaturePropertyUpdate(entry.key, entry.value)
           ],
         ));
       } else {
         // Feature is new, add it
         features.add(feature);
-        final newData = FeatureCollection(features: features);
-        _addedFeaturesByLayer[sourceId] = newData;
+        newFeatures.add(feature);
+      }
+    }
 
-        print(
-            'Adding new feature for source ${sourceId}, feature ${feature.id}');
-        source.updateData(GeoJsonSourceDiff(
-          add: [feature],
-        ));
+    source.updateData(GeoJsonSourceDiff(
+      update: updatedFeatures,
+      add: newFeatures,
+    ));
+
+    final newData = FeatureCollection(features: features);
+    _addedFeaturesByLayer[sourceId] = newData;
+  }
       }
     }
   }

--- a/maplibre_gl_web/lib/src/style/sources/geojson_source.dart
+++ b/maplibre_gl_web/lib/src/style/sources/geojson_source.dart
@@ -1,9 +1,11 @@
 import 'package:maplibre_gl_web/src/geo/geojson.dart';
 import 'package:maplibre_gl_web/src/interop/style/sources/geojson_source_interop.dart';
+import 'package:maplibre_gl_web/src/style/sources/geojson_source_diff.dart';
 import 'package:maplibre_gl_web/src/style/sources/source.dart';
 
 class GeoJsonSource extends Source<GeoJsonSourceJsImpl> {
   FeatureCollection get data => FeatureCollection.fromJsObject(jsObject.data);
+
   String? get promoteId => jsObject.promoteId;
 
   factory GeoJsonSource({
@@ -18,6 +20,9 @@ class GeoJsonSource extends Source<GeoJsonSourceJsImpl> {
 
   GeoJsonSource setData(FeatureCollection featureCollection) =>
       GeoJsonSource.fromJsObject(jsObject.setData(featureCollection.jsObject));
+
+  GeoJsonSource updateData(GeoJsonSourceDiff diff) =>
+      GeoJsonSource.fromJsObject(jsObject.updateData(diff.jsObject));
 
   /// Creates a new GeoJsonSource from a [jsObject].
   GeoJsonSource.fromJsObject(super.jsObject) : super.fromJsObject();

--- a/maplibre_gl_web/lib/src/style/sources/geojson_source_diff.dart
+++ b/maplibre_gl_web/lib/src/style/sources/geojson_source_diff.dart
@@ -1,0 +1,56 @@
+import 'dart:js_interop';
+
+import 'package:maplibre_gl_web/src/geo/geojson.dart';
+import 'package:maplibre_gl_web/src/interop/js.dart';
+import 'package:maplibre_gl_web/src/interop/style/sources/geojson_source_diff_interop.dart';
+
+class GeoJsonSourceDiff extends JsObjectWrapper<GeoJsonSourceDiffJsImpl> {
+  factory GeoJsonSourceDiff({
+    bool? removeAll,
+    List<GeoJsonFeatureId>? remove,
+    List<Feature>? add,
+    List<GeoJsonFeatureDiff>? update,
+  }) {
+    return GeoJsonSourceDiff.fromJsObject(GeoJsonSourceDiffJsImpl(
+      removeAll: removeAll,
+      remove: remove,
+      add: add?.map((feature) => feature.jsObject).nonNulls.toList(),
+      update: update?.map((featureDiff) => featureDiff.jsObject).toList(),
+    ));
+  }
+
+  GeoJsonSourceDiff.fromJsObject(super.jsObject) : super.fromJsObject();
+}
+
+class GeoJsonFeatureDiff extends JsObjectWrapper<GeoJsonFeatureDiffJsImpl> {
+  factory GeoJsonFeatureDiff({
+    GeoJsonFeatureId id,
+    Geometry? newGeometry,
+    bool? removeAllProperties,
+    List<String>? removeProperties,
+    List<FeaturePropertyUpdate>? addOrUpdateProperties,
+  }) {
+    return GeoJsonFeatureDiff.fromJsObject(GeoJsonFeatureDiffJsImpl(
+      id: id,
+      newGeometry: newGeometry?.jsObject,
+      removeAllProperties: removeAllProperties,
+      removeProperties: removeProperties,
+      addOrUpdateProperties:
+          addOrUpdateProperties?.map((property) => property.jsObject).toList(),
+    ));
+  }
+
+  GeoJsonFeatureDiff.fromJsObject(super.jsObject) : super.fromJsObject();
+}
+
+class FeaturePropertyUpdate
+    extends JsObjectWrapper<FeaturePropertyUpdateJsImpl> {
+  factory FeaturePropertyUpdate(String key, dynamic value) {
+    return FeaturePropertyUpdate.fromJsObject(FeaturePropertyUpdateJsImpl(
+      key: key,
+      value: value,
+    ));
+  }
+
+  FeaturePropertyUpdate.fromJsObject(super.jsObject) : super.fromJsObject();
+}


### PR DESCRIPTION
This PR adds batch processing of GeoJSON source feature updates (add, set or remove) by manipulating individual features instead of computing the whole GeoJSON every time.

Platform interface for all platforms now supports setFeatures and removeFeatures (allows processing more feature changes at once). Annotation managers now use this instead of `setAll` they used previously, which recomputed the whole GeoJSON source and sent it to native.

On the web this was achieved by implemented GeoJSONSourceDiff - feature add, set or remove is now implemented by defining a difference from previous state instead of recalculating the whole GeoJSON. New JS interops were defined for this to work.

For native platforms the batch processing is implemented in Java and Swift by updating their local copies of the GeoJSON source. The whole source is then sent to C++ engine for rendering, but the fact that all the updates are processed in native instead of Flutter makes updates faster anyway.

### Testing
Same as always, you have to go and point each package to local copy of flutter-maplibre-gl as they use git versions by default.